### PR TITLE
add newline in between combined

### DIFF
--- a/ExtendedClientScript.php
+++ b/ExtendedClientScript.php
@@ -236,7 +236,7 @@ class ExtendedClientScript extends CClientScript
 			$combinedFile = '';
 
 			foreach ($urls as $key => $file)
-				$combinedFile .= file_get_contents($this->basePath.'/'.$file);
+				$combinedFile .= '\n' . file_get_contents($this->basePath.'/'.$file);
 
 			if ($type == 'js' && $this->compressJs)
 				$combinedFile = $this->minifyJs($combinedFile);


### PR DESCRIPTION
add a newline character when combining files to avoid single line comments in the last line of a file to mess up the next file.

i.e.
file1 ends with:
endOfCode();
`//# sourceMappingURL=/path/to/file.js.map`

file2 starts with

```
/* Copyright info
* more info
*/
function () ...
```

this would result in:
`...e();more info function()...`
